### PR TITLE
Support truncating MongoDB query tag

### DIFF
--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
@@ -42,7 +42,7 @@ type monitor struct {
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
-	if m.cfg.maxQuerySize > 0 {
+	if m.cfg.maxQuerySize > 0 && len(b) > m.cfg.maxQuerySize {
 		b = b[:m.cfg.maxQuerySize]
 	}
 	opts := []tracer.StartSpanOption{

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo.go
@@ -42,6 +42,9 @@ type monitor struct {
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
+	if m.cfg.maxQuerySize > 0 {
+		b = b[:m.cfg.maxQuerySize]
+	}
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMongoDB),
 		tracer.ServiceName(m.cfg.serviceName),

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo_test.go
@@ -122,7 +122,8 @@ func TestTruncation(t *testing.T) {
 	t.Run("zero", func(t *testing.T) {
 		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
 		actual := getQuery(t, 0)
-		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})
 
 	t.Run("positive", func(t *testing.T) {
@@ -134,6 +135,14 @@ func TestTruncation(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {
 		// Should *not* truncate.
 		actual := getQuery(t, -1)
-		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
+	})
+
+	t.Run("greater than query size", func(t *testing.T) {
+		// Should *not* truncate.
+		actual := getQuery(t, 1000) // arbitrary value > the size of the query we will be truncating
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})
 }

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/mongo_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -79,4 +80,60 @@ func Test(t *testing.T) {
 	assert.Equal(t, "go.mongodb.org/mongo-driver.v2", s.Integration())
 	assert.Equal(t, ext.SpanKindClient, s.Tag(ext.SpanKind))
 	assert.Equal(t, "mongodb", s.Tag(ext.DBSystem))
+}
+
+func TestTruncation(t *testing.T) {
+	getQuery := func(t *testing.T, max int) string {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		span, ctx := tracer.StartSpanFromContext(ctx, "mongodb-test")
+
+		addr := "mongodb://localhost:27017/?connect=direct"
+		opts := options.Client()
+		opts.Monitor = NewMonitor(WithMaxQuerySize(max))
+		opts.ApplyURI(addr)
+		client, err := mongo.Connect(opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.
+			Database("test-database").
+			Collection("test-collection").
+			UpdateOne(
+				ctx,
+				bson.D{{Key: "_id", Value: "68536ec8d906742797f5705a"}},
+				bson.D{{Key: "$set", Value: map[string]any{"test-item": "test-value"}}},
+			)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		span.Finish()
+
+		spans := mt.FinishedSpans()
+		return spans[0].Tag("mongodb.query").(string)
+	}
+
+	t.Run("zero", func(t *testing.T) {
+		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
+		actual := getQuery(t, 0)
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		// Should truncate.
+		actual := getQuery(t, 50)
+		assert.Equal(t, actual, `{"update":"test-collection","ordered":true,"lsid":`)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		// Should *not* truncate.
+		actual := getQuery(t, -1)
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+	})
 }

--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
@@ -10,8 +10,9 @@ import (
 )
 
 type config struct {
-	serviceName string
-	spanName    string
+	serviceName  string
+	spanName     string
+	maxQuerySize int
 }
 
 // Option describes options for the Mongo integration.
@@ -35,5 +36,17 @@ func defaults(cfg *config) {
 func WithService(name string) OptionFn {
 	return func(cfg *config) {
 		cfg.serviceName = name
+	}
+}
+
+// WithMaxQuerySize sets the maximum query size (in bytes) before queries
+// are truncated when attached as a span tag.
+//
+// If max is <=0, the query is never truncated.
+//
+// Defaults to zero.
+func WithMaxQuerySize(max int) OptionFn {
+	return func(cfg *config) {
+		cfg.maxQuerySize = max
 	}
 }

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -46,6 +46,9 @@ type monitor struct {
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
+	if m.cfg.maxQuerySize > 0 {
+		b = b[:m.cfg.maxQuerySize]
+	}
 	opts := []tracer.StartSpanOption{
 		tracer.SpanType(ext.SpanTypeMongoDB),
 		tracer.ServiceName(m.cfg.serviceName),

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo.go
@@ -46,7 +46,7 @@ type monitor struct {
 func (m *monitor) Started(ctx context.Context, evt *event.CommandStartedEvent) {
 	hostname, port := peerInfo(evt)
 	b, _ := bson.MarshalExtJSON(evt.Command, false, false)
-	if m.cfg.maxQuerySize > 0 {
+	if m.cfg.maxQuerySize > 0 && len(b) > m.cfg.maxQuerySize {
 		b = b[:m.cfg.maxQuerySize]
 	}
 	opts := []tracer.StartSpanOption{

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -178,7 +178,8 @@ func TestTruncation(t *testing.T) {
 	t.Run("zero", func(t *testing.T) {
 		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
 		actual := getQuery(t, 0)
-		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})
 
 	t.Run("positive", func(t *testing.T) {
@@ -190,6 +191,14 @@ func TestTruncation(t *testing.T) {
 	t.Run("negative", func(t *testing.T) {
 		// Should *not* truncate.
 		actual := getQuery(t, -1)
-		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
+	})
+
+	t.Run("greater than query size", func(t *testing.T) {
+		// Should *not* truncate.
+		actual := getQuery(t, 1000) // arbitrary value > the size of the query we will be truncating
+		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})
 }

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -134,5 +135,61 @@ func TestAnalyticsSettings(t *testing.T) {
 		testutils.SetGlobalAnalyticsRate(t, 0.4)
 
 		assertRate(t, mt, 0.23, WithAnalyticsRate(0.23))
+	})
+}
+
+func TestTruncation(t *testing.T) {
+	getQuery := func(t *testing.T, max int) string {
+		mt := mocktracer.Start()
+		defer mt.Stop()
+
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second*3)
+		defer cancel()
+
+		span, ctx := tracer.StartSpanFromContext(ctx, "mongodb-test")
+
+		addr := "mongodb://localhost:27017/?connect=direct"
+		opts := options.Client()
+		opts.Monitor = NewMonitor(WithMaxQuerySize(max))
+		opts.ApplyURI(addr)
+		client, err := mongo.Connect(ctx, opts)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		_, err = client.
+			Database("test-database").
+			Collection("test-collection").
+			UpdateOne(
+				ctx,
+				bson.D{{Key: "_id", Value: "68536ec8d906742797f5705a"}},
+				bson.D{{Key: "$set", Value: map[string]any{"test-item": "test-value"}}},
+			)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		span.Finish()
+
+		spans := mt.FinishedSpans()
+		return spans[0].Tag("mongodb.query").(string)
+	}
+
+	t.Run("zero", func(t *testing.T) {
+		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
+		actual := getQuery(t, 0)
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
+	})
+
+	t.Run("positive", func(t *testing.T) {
+		// Should truncate.
+		actual := getQuery(t, 50)
+		assert.Equal(t, actual, `{"update":"test-collection","ordered":true,"lsid":`)
+	})
+
+	t.Run("negative", func(t *testing.T) {
+		// Should *not* truncate.
+		actual := getQuery(t, -1)
+		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`))
 	})
 }

--- a/contrib/go.mongodb.org/mongo-driver/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/option.go
@@ -15,6 +15,7 @@ type config struct {
 	serviceName   string
 	spanName      string
 	analyticsRate float64
+	maxQuerySize  int
 }
 
 // Option describes options for the Mongo integration.
@@ -62,5 +63,17 @@ func WithAnalyticsRate(rate float64) OptionFn {
 		} else {
 			cfg.analyticsRate = math.NaN()
 		}
+	}
+}
+
+// WithMaxQuerySize sets the maximum query size (in bytes) before queries
+// are truncated when attached as a span tag.
+//
+// If max is <=0, the query is never truncated.
+//
+// Defaults to zero.
+func WithMaxQuerySize(max int) OptionFn {
+	return func(cfg *config) {
+		cfg.maxQuerySize = max
 	}
 }


### PR DESCRIPTION
### What does this PR do?

This PR adds support for a `WithMaxQuerySize` method to the MongoDB package that enables truncation on the `mongodb.query` span tag.

I also ported this behavior to the new `mongo-driver.v2` package which supports the v2 release of the Mongo drivers.

Opening this PR here first for feedback from our team and then will open on the upstream repo.

The default is to not truncate query span tags, to avoid breaking changes. I'll ask in the upstream PR about whether we could truncate by default instead.

### Motivation

This reduces the memory footprint of tracing Mongo applications that write large documents.

