### PR TITLE
Update WithMaxQuerySize(0) to not attach query

### DIFF
--- a/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver.v2/mongo/option.go
@@ -30,6 +30,7 @@ func (fn OptionFn) apply(cfg *config) {
 func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
+	cfg.maxQuerySize = -1
 }
 
 // WithService sets the given service name for this integration spans.
@@ -42,9 +43,9 @@ func WithService(name string) OptionFn {
 // WithMaxQuerySize sets the maximum query size (in bytes) before queries
 // are truncated when attached as a span tag.
 //
-// If max is <=0, the query is never truncated.
+// If max is < 0, the query is never truncated.
 //
-// Defaults to zero.
+// Defaults to -1.
 func WithMaxQuerySize(max int) OptionFn {
 	return func(cfg *config) {
 		cfg.maxQuerySize = max

--- a/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/mongo_test.go
@@ -139,7 +139,7 @@ func TestAnalyticsSettings(t *testing.T) {
 }
 
 func TestTruncation(t *testing.T) {
-	getQuery := func(t *testing.T, max int) string {
+	getQuery := func(t *testing.T, max int) (string, bool) {
 		mt := mocktracer.Start()
 		defer mt.Stop()
 
@@ -172,32 +172,32 @@ func TestTruncation(t *testing.T) {
 		span.Finish()
 
 		spans := mt.FinishedSpans()
-		return spans[0].Tag("mongodb.query").(string)
+		value, ok := spans[0].Tag("mongodb.query").(string)
+		return value, ok
 	}
 
 	t.Run("zero", func(t *testing.T) {
-		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
-		actual := getQuery(t, 0)
-		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
-		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
+		// Should *not* attach the tag.
+		_, ok := getQuery(t, 0)
+		assert.False(t, ok)
 	})
 
 	t.Run("positive", func(t *testing.T) {
 		// Should truncate.
-		actual := getQuery(t, 50)
+		actual, _ := getQuery(t, 50)
 		assert.Equal(t, actual, `{"update":"test-collection","ordered":true,"lsid":`)
 	})
 
 	t.Run("negative", func(t *testing.T) {
-		// Should *not* truncate.
-		actual := getQuery(t, -1)
+		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
+		actual, _ := getQuery(t, -1)
 		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
 		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})
 
 	t.Run("greater than query size", func(t *testing.T) {
-		// Should *not* truncate.
-		actual := getQuery(t, 1000) // arbitrary value > the size of the query we will be truncating
+		// Should *not* truncate. The actual query contains a random session ID, so we just check the end which is deterministic.
+		actual, _ := getQuery(t, 1000) // arbitrary value > the size of the query we will be truncating
 		wantSuffix := `"u":{"$set":{"test-item":"test-value"}}}]}`
 		assert.True(t, strings.HasSuffix(actual, `"u":{"$set":{"test-item":"test-value"}}}]}`), "query %q does not end with %q", actual, wantSuffix)
 	})

--- a/contrib/go.mongodb.org/mongo-driver/mongo/option.go
+++ b/contrib/go.mongodb.org/mongo-driver/mongo/option.go
@@ -34,6 +34,7 @@ func defaults(cfg *config) {
 	cfg.serviceName = instr.ServiceName(instrumentation.ComponentDefault, nil)
 	cfg.spanName = instr.OperationName(instrumentation.ComponentDefault, nil)
 	cfg.analyticsRate = instr.AnalyticsRate(false)
+	cfg.maxQuerySize = -1
 }
 
 // WithService sets the given service name for this integration spans.
@@ -69,9 +70,9 @@ func WithAnalyticsRate(rate float64) OptionFn {
 // WithMaxQuerySize sets the maximum query size (in bytes) before queries
 // are truncated when attached as a span tag.
 //
-// If max is <=0, the query is never truncated.
+// If max is < 0, the query is never truncated.
 //
-// Defaults to zero.
+// Defaults to -1.
 func WithMaxQuerySize(max int) OptionFn {
 	return func(cfg *config) {
 		cfg.maxQuerySize = max


### PR DESCRIPTION
This PR updates the behavior of `WithMaxQuerySize` when `max=0` to avoid attaching the query tag entirely. This is more intuitive ("max query size of zero") and gives folks a way to disable serializing the command entirely.